### PR TITLE
Bhourahine typos rebase

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,15 +5,9 @@ The open source library `MPIFX <https://www.bitbucket.org/aradi/mpifx>`_ is
 an effort to provide modern Fortran (Fortran 2003) wrappers around
 routines of the MPI library to make their use as simple as possible.
 
-A few essential communication routines are already covered. See the
-documentation or the `online API documentation
-<https://aradi.bitbucket.org/mpifx/api/annotated.html>`_ whether the routines
-you need are there. If not, you are cordially invited to extend MPIFX and to
-share it in order to let others profit from your work. MPIFX is licensed under
-the **simplified BSD license**.
+It currently contains only a few routines so far, but if those happen to be the
+ones you need, feel free to use this project (MPIFX is licensed under the
+**simplified BSD license**).
 
-Information about installation and usage of the library you find in the
-documentation in the source or in the `online documentation
-<https://aradi.bitbucket.org/mpifx/>`_. Project status, current source code,
-bugtracker etc. can be found on the `MPIFX project home page
-<https://www.bitbucket.org/aradi/mpifx>`_.
+If your desired MPI routine is not yet wrapped up, feel free to contribute to
+the project to include the target functionality.

--- a/src/mpifx_common.F90
+++ b/src/mpifx_common.F90
@@ -6,6 +6,8 @@ module mpifx_common_module
   use mpi
   use mpifx_helper_module
   use mpifx_comm_module
+  implicit none
+
   public
 
 end module mpifx_common_module

--- a/src/mpifx_recv.m4
+++ b/src/mpifx_recv.m4
@@ -5,7 +5,7 @@ dnl *** mpifx_recv
 dnl ************************************************************************
 
 define(`_subroutine_mpifx_recv', `dnl
-dnl $1: subroutien suffix
+dnl $1: subroutine suffix
 dnl $2: dummy arguments type
 dnl $3: dummy arguments rank specifier ("", (:), (:,:), etc.)
 dnl $4: dummy arguments size (1 or size(dummyname))

--- a/src/mpifx_send.m4
+++ b/src/mpifx_send.m4
@@ -5,7 +5,7 @@ dnl *** mpifx_send
 dnl ************************************************************************
 
 define(`_subroutine_mpifx_send', `dnl
-dnl $1: subroutien suffix
+dnl $1: subroutine suffix
 dnl $2: dummy arguments type
 dnl $3: dummy arguments rank specifier ("", (:), (:,:), etc.)
 dnl $4: dummy arguments size (1 or len(msg) or size(msg))

--- a/test/test_bcast.f90
+++ b/test/test_bcast.f90
@@ -1,6 +1,7 @@
 program test_bcast
   use libmpifx_module
-
+  implicit none
+  
   integer, parameter :: dp = kind(1.0d0)
   integer, parameter :: sp = kind(1.0)
 


### PR DESCRIPTION
Typos corrected by Ben. It a separate branch on bitbucket. I've *rebased* it on develop to keep history clean and simple.