### PR TITLE
Fix undefined refs

### DIFF
--- a/lib/mpifx_recv.fpp
+++ b/lib/mpifx_recv.fpp
@@ -6,7 +6,7 @@
 module mpifx_recv_module
   use mpi
   use mpifx_comm_module, only : mpifx_comm
-  use mpifx_helper_module, only : dp, sp
+  use mpifx_helper_module, only : dp, sp, getoptarg, setoptarg, handle_errorflag
   implicit none
   private
 

--- a/lib/mpifx_send.fpp
+++ b/lib/mpifx_send.fpp
@@ -6,7 +6,7 @@
 module mpifx_send_module
   use mpi
   use mpifx_comm_module, only : mpifx_comm
-  use mpifx_helper_module, only : default_tag, dp, sp
+  use mpifx_helper_module, only : default_tag, dp, sp, getoptarg, handle_errorflag
   implicit none
   private
 


### PR DESCRIPTION
I happily used the latest revision of mpifx compiling dftb+ on Juwels, fixing the known issue of type(c_ptr) errors. 
However I had "undefined refs" using gnu 12.3 
This PR is to fix the issue adding few missing refs to the use, only list
