### PR TITLE
Switch to mpi f08 in all files

### DIFF
--- a/lib/mpifx_abort.fpp
+++ b/lib/mpifx_abort.fpp
@@ -1,6 +1,6 @@
 !> Contains wrapper for \c MPI_ABORT.
 module mpifx_abort_module
-  use mpi
+  use mpi_f08
   use mpifx_comm_module, only : mpifx_comm
   use mpifx_helper_module, only : handle_errorflag
   implicit none
@@ -47,7 +47,7 @@ contains
       errorcode0 = -1
     end if
 
-    call mpi_abort(mycomm%id, errorcode0, error0)
+    call mpi_abort(mycomm%comm, errorcode0, error0)
     call handle_errorflag(error0, "MPI_ABORT in mpifx_abort", error)
 
   end subroutine mpifx_abort

--- a/lib/mpifx_abort.fpp
+++ b/lib/mpifx_abort.fpp
@@ -1,6 +1,6 @@
 !> Contains wrapper for \c MPI_ABORT.
 module mpifx_abort_module
-  use mpi_f08
+  use mpi_f08, only : mpi_abort
   use mpifx_comm_module, only : mpifx_comm
   use mpifx_helper_module, only : handle_errorflag
   implicit none

--- a/lib/mpifx_allgather.fpp
+++ b/lib/mpifx_allgather.fpp
@@ -4,7 +4,8 @@
 
 !> Contains wrapper for \c MPI_ALLGATHER
 module mpifx_allgather_module
-  use mpi_f08
+  use mpi_f08, only : mpi_allgather, mpi_character, mpi_complex, mpi_double_complex,&
+      & mpi_double_precision, mpi_integer, mpi_logical, mpi_real
   use mpifx_comm_module, only : mpifx_comm
   use mpifx_helper_module, only : dp, handle_errorflag, sp
   implicit none

--- a/lib/mpifx_allgather.fpp
+++ b/lib/mpifx_allgather.fpp
@@ -4,7 +4,7 @@
 
 !> Contains wrapper for \c MPI_ALLGATHER
 module mpifx_allgather_module
-  use mpi
+  use mpi_f08
   use mpifx_comm_module, only : mpifx_comm
   use mpifx_helper_module, only : dp, handle_errorflag, sp
   implicit none
@@ -122,7 +122,7 @@ contains
     @:ASSERT(size(recv) == ${SIZE}$ * mycomm%size)
     @:ASSERT(size(recv, dim=${RANK}$) == size(send, dim=${RANK}$) * mycomm%size)
 
-    call mpi_allgather(send, ${COUNT}$, ${MPITYPE}$, recv, ${COUNT}$, ${MPITYPE}$, mycomm%id,&
+    call mpi_allgather(send, ${COUNT}$, ${MPITYPE}$, recv, ${COUNT}$, ${MPITYPE}$, mycomm%comm,&
         & error0)
     call handle_errorflag(error0, 'MPI_ALLGATHER in mpifx_allgather_${SUFFIX}$', error)
 
@@ -162,7 +162,7 @@ contains
     @:ASSERT(size(recv, dim=${RANK + 1}$) == mycomm%size)
 
     call mpi_allgather(send, ${COUNT}$, ${MPITYPE}$, recv, ${COUNT}$, ${MPITYPE}$,&
-        & mycomm%id, error0)
+        & mycomm%comm, error0)
     call handle_errorflag(error0, 'MPI_ALLGATHER in mpifx_allgather_${SUFFIX}$', error)
 
   end subroutine mpifx_allgather_${SUFFIX}$

--- a/lib/mpifx_allgatherv.fpp
+++ b/lib/mpifx_allgatherv.fpp
@@ -106,7 +106,8 @@
 
 !> Contains wrapper for \c MPI_allgatherv
 module mpifx_allgatherv_module
-  use mpi_f08
+  use mpi_f08, only : mpi_allgatherv, mpi_character, mpi_complex, mpi_double_complex,&
+      & mpi_double_precision, mpi_integer, mpi_logical, mpi_real
   use mpifx_comm_module, only : mpifx_comm
   use mpifx_helper_module, only : dp, handle_errorflag, sp
   implicit none

--- a/lib/mpifx_allgatherv.fpp
+++ b/lib/mpifx_allgatherv.fpp
@@ -45,7 +45,7 @@
     end if
 
     call mpi_allgatherv(send, size(send), ${MPI_TYPE}$, recv, recvcounts, displs0, &
-        & ${MPI_TYPE}$, mycomm%id, error0)
+        & ${MPI_TYPE}$, mycomm%comm, error0)
 
     call handle_errorflag(error0, "MPI_ALLGATHERV in mpifx_allgatherv_${SUFFIX}$", error)
 
@@ -96,7 +96,7 @@
     end if
 
     call mpi_allgatherv(send, ${SEND_BUFFER_SIZE}$, ${MPI_TYPE}$, recv, recvcounts, displs0, &
-         & ${MPI_TYPE}$,  mycomm%id, error0)
+         & ${MPI_TYPE}$,  mycomm%comm, error0)
 
     call handle_errorflag(error0, "MPI_ALLGATHERV in mpifx_allgatherv_${SUFFIX}$", error)
 
@@ -106,7 +106,7 @@
 
 !> Contains wrapper for \c MPI_allgatherv
 module mpifx_allgatherv_module
-  use mpi
+  use mpi_f08
   use mpifx_comm_module, only : mpifx_comm
   use mpifx_helper_module, only : dp, handle_errorflag, sp
   implicit none

--- a/lib/mpifx_allreduce.fpp
+++ b/lib/mpifx_allreduce.fpp
@@ -4,7 +4,8 @@
 
 !> Contains wrapper for \c MPI_ALLREDUCE.
 module mpifx_allreduce_module
-  use mpi_f08
+  use mpi_f08, only : mpi_allreduce, mpi_complex, mpi_double_complex, mpi_double_precision,&
+      & mpi_in_place, mpi_integer, mpi_logical, mpi_op, mpi_real
   use mpifx_comm_module, only : mpifx_comm
   use mpifx_helper_module, only : dp, handle_errorflag, sp
   implicit none

--- a/lib/mpifx_barrier.fpp
+++ b/lib/mpifx_barrier.fpp
@@ -2,7 +2,7 @@
 
 !> Contains wrapper for \c MPI_BARRIER.
 module mpifx_barrier_module
-  use mpi
+  use mpi_f08
   use mpifx_comm_module, only : mpifx_comm
   use mpifx_helper_module, only : handle_errorflag
   implicit none
@@ -40,7 +40,7 @@ contains
 
     integer :: error0
 
-    call mpi_barrier(mycomm%id, error0)
+    call mpi_barrier(mycomm%comm, error0)
     call handle_errorflag(error0, "MPI_BARRIER in mpifx_barrier", error)
 
   end subroutine mpifx_barrier

--- a/lib/mpifx_barrier.fpp
+++ b/lib/mpifx_barrier.fpp
@@ -2,7 +2,7 @@
 
 !> Contains wrapper for \c MPI_BARRIER.
 module mpifx_barrier_module
-  use mpi_f08
+  use mpi_f08, only : mpi_barrier
   use mpifx_comm_module, only : mpifx_comm
   use mpifx_helper_module, only : handle_errorflag
   implicit none

--- a/lib/mpifx_bcast.fpp
+++ b/lib/mpifx_bcast.fpp
@@ -4,7 +4,8 @@
 
 !> Contains wrapper for \c MPI_BCAST.
 module mpifx_bcast_module
-  use mpi_f08
+  use mpi_f08, only : mpi_bcast, mpi_character, mpi_complex, mpi_double_complex,&
+      & mpi_double_precision, mpi_integer, mpi_logical, mpi_real
   use mpifx_comm_module, only : mpifx_comm
   use mpifx_helper_module, only : dp, getoptarg, handle_errorflag, sp
   implicit none

--- a/lib/mpifx_bcast.fpp
+++ b/lib/mpifx_bcast.fpp
@@ -4,7 +4,7 @@
 
 !> Contains wrapper for \c MPI_BCAST.
 module mpifx_bcast_module
-  use mpi
+  use mpi_f08
   use mpifx_comm_module, only : mpifx_comm
   use mpifx_helper_module, only : dp, getoptarg, handle_errorflag, sp
   implicit none
@@ -75,7 +75,7 @@ contains
     #:set COUNT = ('len(msg) * ' + SIZE if HASLENGTH else SIZE)
 
     call getoptarg(mycomm%leadrank, root0, root)
-    call mpi_bcast(msg, ${COUNT}$, ${MPITYPE}$, root0, mycomm%id, error0)
+    call mpi_bcast(msg, ${COUNT}$, ${MPITYPE}$, root0, mycomm%comm, error0)
     call handle_errorflag(error0, "MPI_BCAST in mpifx_bcast_${SUFFIX}$", error)
 
   end subroutine mpifx_bcast_${SUFFIX}$

--- a/lib/mpifx_comm.fpp
+++ b/lib/mpifx_comm.fpp
@@ -1,6 +1,6 @@
 !> Contains the extended MPI communicator.
 module mpifx_comm_module
-  use mpi_f08
+  use mpi_f08, only : mpi_comm, mpi_comm_world, mpi_info_null
   use mpifx_helper_module, only : getoptarg, handle_errorflag
   implicit none
   private
@@ -49,11 +49,13 @@ contains
     integer, intent(out), optional :: error
 
     integer :: error0
+    type(mpi_comm) :: default_comm
+    default_comm = MPI_COMM_WORLD
 
     if (present(comm)) then
       self%comm = comm
     else
-      self%comm = MPI_COMM_WORLD
+      self%comm = default_comm
     end if
     self%id = self%comm%mpi_val
     call mpi_comm_size(self%comm, self%size, error0)

--- a/lib/mpifx_constants.fpp
+++ b/lib/mpifx_constants.fpp
@@ -1,7 +1,7 @@
 !> Exports some MPI constants.
 !! \cond HIDDEN
 module mpifx_constants_module
-  use mpi
+  use mpi_f08
   private
 
   public :: MPI_MAX, MPI_MIN, MPI_SUM, MPI_PROD

--- a/lib/mpifx_constants.fpp
+++ b/lib/mpifx_constants.fpp
@@ -1,7 +1,7 @@
 !> Exports some MPI constants.
 !! \cond HIDDEN
 module mpifx_constants_module
-  use mpi_f08
+  use mpi_f08, only : MPI_ADDRESS_KIND
   private
 
   public :: MPI_MAX, MPI_MIN, MPI_SUM, MPI_PROD

--- a/lib/mpifx_finalize.fpp
+++ b/lib/mpifx_finalize.fpp
@@ -1,6 +1,6 @@
 !> Contains wrapper for \c MPI_FINALIZE.
 module mpifx_finalize_module
-  use mpi
+  use mpi_f08
   use mpifx_comm_module, only : mpifx_comm
   use mpifx_helper_module, only : handle_errorflag
   implicit none

--- a/lib/mpifx_finalize.fpp
+++ b/lib/mpifx_finalize.fpp
@@ -1,6 +1,6 @@
 !> Contains wrapper for \c MPI_FINALIZE.
 module mpifx_finalize_module
-  use mpi_f08
+  use mpi_f08, only : mpi_finalize
   use mpifx_comm_module, only : mpifx_comm
   use mpifx_helper_module, only : handle_errorflag
   implicit none

--- a/lib/mpifx_gather.fpp
+++ b/lib/mpifx_gather.fpp
@@ -4,7 +4,7 @@
 
 !> Contains wrapper for \c MPI_GATHER
 module mpifx_gather_module
-  use mpi
+  use mpi_f08
   use mpifx_comm_module, only : mpifx_comm
   use mpifx_helper_module, only : dp, getoptarg, handle_errorflag, sp
   implicit none
@@ -135,7 +135,7 @@ contains
 
     call getoptarg(mycomm%leadrank, root0, root)
     call mpi_gather(send, ${COUNT}$, ${MPITYPE}$, recv, ${COUNT}$, ${MPITYPE}$, root0,&
-        & mycomm%id, error0)
+        & mycomm%comm, error0)
     call handle_errorflag(error0, "MPI_GATHER in mpifx_gather_${SUFFIX}$", error)
 
   end subroutine mpifx_gather_${SUFFIX}$
@@ -171,7 +171,7 @@ contains
     @:ASSERT(.not. mycomm%lead .or. size(recv, dim=${RANK + 1}$) == mycomm%size)
 
     call getoptarg(mycomm%leadrank, root0, root)
-    call mpi_gather(send, ${SIZE}$, ${MPITYPE}$, recv, ${SIZE}$, ${MPITYPE}$, root0, mycomm%id,&
+    call mpi_gather(send, ${SIZE}$, ${MPITYPE}$, recv, ${SIZE}$, ${MPITYPE}$, root0, mycomm%comm,&
         & error0)
     call handle_errorflag(error0, "MPI_GATHER in mpifx_gather_${SUFFIX}$", error)
 

--- a/lib/mpifx_gather.fpp
+++ b/lib/mpifx_gather.fpp
@@ -4,7 +4,8 @@
 
 !> Contains wrapper for \c MPI_GATHER
 module mpifx_gather_module
-  use mpi_f08
+  use mpi_f08, only : mpi_double_complex, mpi_double_precision, mpi_character, mpi_complex,&
+      & mpi_gather, mpi_integer, mpi_logical, mpi_real
   use mpifx_comm_module, only : mpifx_comm
   use mpifx_helper_module, only : dp, getoptarg, handle_errorflag, sp
   implicit none

--- a/lib/mpifx_gatherv.fpp
+++ b/lib/mpifx_gatherv.fpp
@@ -67,7 +67,7 @@
     end if
 
     call mpi_gatherv(send, size(send), ${MPI_TYPE}$, recv, recvcounts, displs0, &
-        & ${MPI_TYPE}$, root0, mycomm%id, error0)
+        & ${MPI_TYPE}$, root0, mycomm%comm, error0)
 
     call handle_errorflag(error0, "MPI_GATHERV in mpifx_gatherv_${SUFFIX}$", error)
 
@@ -120,7 +120,7 @@
     end if
 
     call mpi_gatherv(send, ${SEND_SIZE}$, ${MPI_TYPE}$, recv, recvcounts, displs0, &
-         & ${MPI_TYPE}$,  root0, mycomm%id, error0)
+         & ${MPI_TYPE}$,  root0, mycomm%comm, error0)
 
     call handle_errorflag(error0, "MPI_GATHERV in mpifx_gatherv_${SUFFIX}$", error)
 
@@ -131,7 +131,7 @@
 
 !> Contains wrapper for \c MPI_gatherv
 module mpifx_gatherv_module
-  use mpi
+  use mpi_f08
   use mpifx_comm_module, only : mpifx_comm
   use mpifx_helper_module, only : dp, handle_errorflag, sp
   implicit none

--- a/lib/mpifx_gatherv.fpp
+++ b/lib/mpifx_gatherv.fpp
@@ -131,7 +131,8 @@
 
 !> Contains wrapper for \c MPI_gatherv
 module mpifx_gatherv_module
-  use mpi_f08
+  use mpi_f08, only : mpi_character, MPI_COMM_WORLD, mpi_complex, mpi_double_complex,&
+      & mpi_double_precision, mpi_integer, mpi_logical, mpi_real
   use mpifx_comm_module, only : mpifx_comm
   use mpifx_helper_module, only : dp, handle_errorflag, sp
   implicit none

--- a/lib/mpifx_get_processor_name.fpp
+++ b/lib/mpifx_get_processor_name.fpp
@@ -1,6 +1,6 @@
 !> Contains the extended MPI communicator.
 module mpifx_get_processor_name_module
-  use mpi_f08
+  use mpi_f08, only : mpi_get_processor_name, MPI_MAX_PROCESSOR_NAME
   implicit none
   private
 

--- a/lib/mpifx_get_processor_name.fpp
+++ b/lib/mpifx_get_processor_name.fpp
@@ -1,6 +1,6 @@
 !> Contains the extended MPI communicator.
 module mpifx_get_processor_name_module
-  use mpi
+  use mpi_f08
   implicit none
   private
 

--- a/lib/mpifx_helper.fpp
+++ b/lib/mpifx_helper.fpp
@@ -4,7 +4,7 @@
 !> Exports constants and helper routine(s).
 !! \cond HIDDEN
 module mpifx_helper_module
-  use mpi_f08
+  use mpi_f08, only : mpi_abort, MPI_COMM_WORLD
   use, intrinsic :: iso_fortran_env, only : stderr => error_unit
   use mpifx_constants_module, only : MPIFX_ASSERT_FAILED, MPIFX_UNHANDLED_ERROR
   implicit none

--- a/lib/mpifx_helper.fpp
+++ b/lib/mpifx_helper.fpp
@@ -4,7 +4,7 @@
 !> Exports constants and helper routine(s).
 !! \cond HIDDEN
 module mpifx_helper_module
-  use mpi
+  use mpi_f08
   use, intrinsic :: iso_fortran_env, only : stderr => error_unit
   use mpifx_constants_module, only : MPIFX_ASSERT_FAILED, MPIFX_UNHANDLED_ERROR
   implicit none

--- a/lib/mpifx_init.fpp
+++ b/lib/mpifx_init.fpp
@@ -1,6 +1,6 @@
 !> Contains wrapper for \c MPI_INIT.
 module mpifx_init_module
-  use mpi
+  use mpi_f08
   use mpifx_comm_module, only : mpifx_comm
   use mpifx_constants_module, only : MPIFX_UNHANDLED_ERROR
   use mpifx_helper_module, only : handle_errorflag

--- a/lib/mpifx_init.fpp
+++ b/lib/mpifx_init.fpp
@@ -1,6 +1,6 @@
 !> Contains wrapper for \c MPI_INIT.
 module mpifx_init_module
-  use mpi_f08
+  use mpi_f08, only : mpi_abort, MPI_COMM_WORLD, mpi_init, mpi_init_thread
   use mpifx_comm_module, only : mpifx_comm
   use mpifx_constants_module, only : MPIFX_UNHANDLED_ERROR
   use mpifx_helper_module, only : handle_errorflag

--- a/lib/mpifx_recv.fpp
+++ b/lib/mpifx_recv.fpp
@@ -4,9 +4,11 @@
 
 !> Contains wrapper for \c MPI_RECV
 module mpifx_recv_module
-  use mpi_f08
+  use mpi_f08, only : MPI_ANY_SOURCE, MPI_ANY_TAG, mpi_character, mpi_complex, mpi_double_complex,&
+      & mpi_double_precision, mpi_integer, mpi_logical, mpi_real, mpi_status, mpi_status_f082f,&
+      & MPI_STATUS_SIZE
   use mpifx_comm_module, only : mpifx_comm
-  use mpifx_helper_module, only : dp, sp
+  use mpifx_helper_module, only : dp, sp, getoptarg, handle_errorflag
   implicit none
   private
 
@@ -81,6 +83,8 @@ contains
 
     integer :: source0, tag0, error0
     type(mpi_status) :: status0
+
+    print *, "routine mpif08"
 
     call getoptarg(MPI_ANY_TAG, tag0, tag)
     call getoptarg(MPI_ANY_SOURCE, source0, source)

--- a/lib/mpifx_reduce.fpp
+++ b/lib/mpifx_reduce.fpp
@@ -4,7 +4,8 @@
 
 !> Contains wrapper for \c MPI_REDUCE.
 module mpifx_reduce_module
-  use mpi_f08
+  use mpi_f08, only : mpi_complex, mpi_double_complex, mpi_double_precision, MPI_IN_PLACE,&
+      & mpi_integer, mpi_logical, mpi_op, mpi_real, mpi_reduce
   use mpifx_comm_module, only : mpifx_comm
   use mpifx_helper_module, only : dp, getoptarg, handle_errorflag, sp
   implicit none

--- a/lib/mpifx_scatter.fpp
+++ b/lib/mpifx_scatter.fpp
@@ -4,7 +4,8 @@
 
 !> Contains wrapper for \c MPI_SCATTER
 module mpifx_scatter_module
-  use mpi_f08
+  use mpi_f08, only : mpi_double_complex, mpi_double_precision, mpi_character, mpi_complex,&
+      & mpi_integer, mpi_logical, mpi_real, mpi_scatter
   use mpifx_comm_module, only : mpifx_comm
   use mpifx_helper_module, only : dp, getoptarg, handle_errorflag, sp
   implicit none

--- a/lib/mpifx_scatter.fpp
+++ b/lib/mpifx_scatter.fpp
@@ -4,7 +4,7 @@
 
 !> Contains wrapper for \c MPI_SCATTER
 module mpifx_scatter_module
-  use mpi
+  use mpi_f08
   use mpifx_comm_module, only : mpifx_comm
   use mpifx_helper_module, only : dp, getoptarg, handle_errorflag, sp
   implicit none
@@ -124,7 +124,7 @@ contains
 
     call getoptarg(mycomm%leadrank, root0, root)
     call mpi_scatter(send, ${COUNT}$, ${MPITYPE}$, recv, ${COUNT}$, ${MPITYPE}$, root0,&
-        & mycomm%id, error0)
+        & mycomm%comm, error0)
     call handle_errorflag(error0, "MPI_SCATTER in mpifx_scatter_${SUFFIX}$", error)
 
   end subroutine mpifx_scatter_${SUFFIX}$
@@ -164,7 +164,7 @@ contains
 
     call getoptarg(mycomm%leadrank, root0, root)
     call mpi_scatter(send, ${COUNT}$, ${MPITYPE}$, recv, ${COUNT}$, ${MPITYPE}$, root0,&
-        & mycomm%id, error0)
+        & mycomm%comm, error0)
     call handle_errorflag(error0, "MPI_SCATTER in mpifx_scatter_${SUFFIX}$", error)
 
   end subroutine mpifx_scatter_${SUFFIX}$

--- a/lib/mpifx_scatterv.fpp
+++ b/lib/mpifx_scatterv.fpp
@@ -4,7 +4,8 @@
 
 !> Contains wrapper for \c MPI_SCATTER
 module mpifx_scatterv_module
-  use mpi_f08
+  use mpi_f08, only : mpi_double_complex, mpi_double_precision, mpi_character, mpi_complex,&
+      & mpi_integer, mpi_logical, mpi_real, mpi_scatterv
   use mpifx_comm_module, only : mpifx_comm
   use mpifx_helper_module, only : dp, getoptarg, handle_errorflag, sp
   implicit none

--- a/lib/mpifx_scatterv.fpp
+++ b/lib/mpifx_scatterv.fpp
@@ -4,7 +4,7 @@
 
 !> Contains wrapper for \c MPI_SCATTER
 module mpifx_scatterv_module
-  use mpi
+  use mpi_f08
   use mpifx_comm_module, only : mpifx_comm
   use mpifx_helper_module, only : dp, getoptarg, handle_errorflag, sp
   implicit none
@@ -131,7 +131,7 @@ contains
       end if
     end if
     call mpi_scatterv(send, sendcounts, displs0, ${MPITYPE}$, recv, ${SIZE}$, ${MPITYPE}$, root0,&
-        & mycomm%id, error0)
+        & mycomm%comm, error0)
 
     call handle_errorflag(error0, "MPI_SCATTER in mpifx_scatterv_${SUFFIX}$", error)
 
@@ -192,7 +192,7 @@ contains
     end if
 
     call mpi_scatterv(send, sendcounts, displs0, ${MPITYPE}$, recv, ${COUNT}$, ${MPITYPE}$, root0,&
-        & mycomm%id, error0)
+        & mycomm%comm, error0)
     call handle_errorflag(error0, "MPI_SCATTER in mpifx_scatterv_${SUFFIX}$", error)
 
   end subroutine mpifx_scatterv_${SUFFIX}$

--- a/lib/mpifx_send.fpp
+++ b/lib/mpifx_send.fpp
@@ -4,7 +4,7 @@
 
 !> Contains wrapper for \c MPI_SEND
 module mpifx_send_module
-  use mpi
+  use mpi_f08
   use mpifx_comm_module, only : mpifx_comm
   use mpifx_helper_module, only : default_tag, dp, sp
   implicit none
@@ -81,7 +81,7 @@ contains
     #:set COUNT = ('len(msg) * ' + SIZE if HASLENGTH else SIZE)
 
     call getoptarg(default_tag, tag0, tag)
-    call mpi_send(msg, ${COUNT}$, ${MPITYPE}$, dest, tag0, mycomm%id, error0)
+    call mpi_send(msg, ${COUNT}$, ${MPITYPE}$, dest, tag0, mycomm%comm, error0)
     call handle_errorflag(error0, "MPI_SEND in mpifx_send_${SUFFIX}$", error)
 
   end subroutine mpifx_send_${SUFFIX}$

--- a/lib/mpifx_send.fpp
+++ b/lib/mpifx_send.fpp
@@ -4,9 +4,10 @@
 
 !> Contains wrapper for \c MPI_SEND
 module mpifx_send_module
-  use mpi_f08
+  use mpi_f08, only: mpi_character, mpi_complex, mpi_double_complex, mpi_double_precision,&
+      & mpi_integer, mpi_logical, mpi_real, mpi_send
   use mpifx_comm_module, only : mpifx_comm
-  use mpifx_helper_module, only : default_tag, dp, sp
+  use mpifx_helper_module, only : default_tag, dp, sp, getoptarg, handle_errorflag
   implicit none
   private
 

--- a/lib/mpifx_win.fpp
+++ b/lib/mpifx_win.fpp
@@ -4,7 +4,7 @@
 
 !> Contains routined for MPI shared memory windows.
 module mpifx_win_module
-  use mpi_f08
+  use mpi_f08, only : MPI_ADDRESS_KIND, mpi_comm, MPI_INFO_NULL, MPI_MODE_NOCHECK, mpi_win
   use mpifx_helper_module, only : handle_errorflag, sp, dp
   use mpifx_comm_module, only : mpifx_comm
   use mpifx_constants_module, only : MPIFX_SIZE_T

--- a/lib/mpifx_win.fpp
+++ b/lib/mpifx_win.fpp
@@ -88,7 +88,7 @@ contains
       local_mem_size = int(global_length, kind=MPI_ADDRESS_KIND) * disp_unit
     end if
 
-    self%comm%mpi_val = mycomm%id
+    self%comm = mycomm%comm
     call mpi_win_allocate_shared(local_mem_size, disp_unit, MPI_INFO_NULL, self%comm,&
         & local_baseptr, self%win, error0)
     call handle_errorflag(error0,&

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,7 +13,8 @@ set(targets
   test_reduce
   test_scatter
   test_scatterv
-  test_win_shared_mem)
+  test_win_shared_mem
+  test_send_recv)
 
 set(sources-helper
   testhelper.f90)


### PR DESCRIPTION
This PR might influence the supported versions of OpenMPI negatively. As mentioned in https://github.com/open-mpi/ompi/issues/12587 there is a problem when using only-imports for "MPI_Status_f082f". This is a problem for certain 5.0.x branches.

Additionally, it brakes/limits the backwards compatibility for "mpifx_recv" due to changes to the optional "status" argument.